### PR TITLE
add initial Bicep templates for Azure App Service Environment deployment

### DIFF
--- a/ase/.cheatsheet
+++ b/ase/.cheatsheet
@@ -1,0 +1,2 @@
+az deployment sub create --verbose --location italynorth --name asedemo --template-file ./main.bicep
+

--- a/ase/ase.bicep
+++ b/ase/ase.bicep
@@ -1,0 +1,280 @@
+param resourceLocation string = 'swedencentral'
+
+param regionName string = 'global'
+
+param globalPrivatAddressPrefix string = '10.0.0.0/8'
+param addressPrefixBastion string = '10.0.0.128/29'
+param addressPrefixHub string = '10.0.0.0/24' 
+param addressPrefixApplicationGateway string = '10.0.0.192/26'
+param applicationGatewayIpAdress string = '10.0.0.196'
+param addressPrefixUser string = '10.0.0.136/29'
+param adressPrefixASE string = '10.0.0.0/25'
+
+module virtualNetwork 'br/public:avm/res/network/virtual-network:0.5.2' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-network-${regionName}'
+  params: {
+    // Required parameters
+    addressPrefixes: [
+      addressPrefixHub
+    ]
+    name: 'vnet-${regionName}'
+    // Non-required parameters
+    location: resourceLocation
+    subnets: [
+      {
+        name: 'ApplicationGatewaySubnet'
+        addressPrefix: addressPrefixApplicationGateway
+      }
+      {
+        name: 'ASESubnet'
+        addressPrefix: adressPrefixASE
+        delegation: 'Microsoft.Web/hostingEnvironments'
+      }
+      {
+        name: 'AzureBastionSubnet'
+        addressPrefix: addressPrefixBastion
+        // No route table can be attached
+      }
+      {
+        name: 'UserSubnet'
+        addressPrefix: addressPrefixUser
+        // No route table can be attached
+      }
+    ]
+  }
+}
+
+module bastionHost 'br/public:avm/res/network/bastion-host:0.1.1' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}Bastion'
+  params: {
+    // Required parameters
+    name: '${regionName}Bastion'
+    vNetId: virtualNetwork.outputs.resourceId
+    scaleUnits: 1 // testing reducing costs
+    skuName: 'Basic' // testing reducing costs
+    location: resourceLocation
+  }
+}
+
+module asEnvironment 'br/public:avm/res/web/hosting-environment:0.2.1' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-ase-${regionName}'
+  params: {
+    // Required parameters
+    name: 'ase-${regionName}'
+    subnetResourceId: virtualNetwork.outputs.subnetResourceIds[1]
+    // Non-required parameters
+    clusterSettings: [
+      {
+        name: 'DisableTls1.0'
+        value: '1'
+      }
+    ]
+    internalLoadBalancingMode: 'Web, Publishing'
+    kind: 'ASEv3'
+    location: resourceLocation
+    managedIdentities: {
+      systemAssigned: true
+    }
+    networkConfiguration: {
+      properties: {
+        allowNewPrivateEndpointConnections: true
+        ftpEnabled: true
+        inboundIpAddressOverride: '10.0.0.10'
+        remoteDebugEnabled: true
+      }
+    }
+    tags: {
+      hostingEnvironmentName: 'ase-${regionName}'
+      resourceType: 'App Service Environment'
+    }
+    upgradePreference: 'Early'
+    zoneRedundant: true
+  }
+}
+
+module appplan1 'br/public:avm/res/web/serverfarm:0.4.1' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-appplan1-${regionName}'
+  params: {
+    // Required parameters
+    name: 'appplan1-${regionName}'
+    // Non-required parameters
+    kind: 'app'
+    location: resourceLocation
+    appServiceEnvironmentId: asEnvironment.outputs.resourceId
+    perSiteScaling: true
+    skuCapacity: 3
+    skuName: 'I1v2'
+    tags: {
+      Environment: 'App Plan 1'
+      Role: 'Various'
+    }
+    zoneRedundant: true
+  }
+}
+
+module webapp1 'br/public:avm/res/web/site:0.11.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-webapp1-${regionName}'
+  params: {
+    // Required parameters
+    kind: 'app'
+    name: 'webapp1-${regionName}'
+    serverFarmResourceId: appplan1.outputs.resourceId
+    // Non-required parameters
+    basicPublishingCredentialsPolicies: [
+      {
+        allow: false
+        name: 'ftp'
+      }
+      {
+        allow: false
+        name: 'scm'
+      }
+    ]
+    httpsOnly: true
+    location: resourceLocation
+    managedIdentities: {
+      systemAssigned: true
+    }
+    publicNetworkAccess: 'Disabled'
+    scmSiteAlsoStopped: true
+    siteConfig: {
+      alwaysOn: true
+    }
+    slots: [
+      {
+        basicPublishingCredentialsPolicies: [
+          {
+            allow: false
+            name: 'ftp'
+          }
+          {
+            allow: false
+            name: 'scm'
+          }
+        ]
+        name: 'prod'
+        siteConfig: {
+          alwaysOn: true
+        }
+      }
+      {
+        basicPublishingCredentialsPolicies: [
+          {
+            name: 'ftp'
+          }
+          {
+            name: 'scm'
+          }
+        ]
+        name: 'dev'
+      }
+    ]
+    vnetContentShareEnabled: true
+    vnetImagePullEnabled: true
+    vnetRouteAllEnabled: true
+  }
+}
+
+module webapp2 'br/public:avm/res/web/site:0.11.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-webapp2-${regionName}'
+  params: {
+    // Required parameters
+    kind: 'app'
+    name: 'webapp2-${regionName}'
+    serverFarmResourceId: appplan1.outputs.resourceId
+    // Non-required parameters
+    basicPublishingCredentialsPolicies: [
+      {
+        allow: false
+        name: 'ftp'
+      }
+      {
+        allow: false
+        name: 'scm'
+      }
+    ]
+    httpsOnly: true
+    location: resourceLocation
+    managedIdentities: {
+      systemAssigned: true
+    }
+    publicNetworkAccess: 'Disabled'
+    scmSiteAlsoStopped: true
+    siteConfig: {
+      alwaysOn: true
+    }
+    slots: [
+      {
+        basicPublishingCredentialsPolicies: [
+          {
+            allow: false
+            name: 'ftp'
+          }
+          {
+            allow: false
+            name: 'scm'
+          }
+        ]
+        name: 'prod'
+        siteConfig: {
+          alwaysOn: true
+        }
+      }
+      {
+        basicPublishingCredentialsPolicies: [
+          {
+            name: 'ftp'
+          }
+          {
+            name: 'scm'
+          }
+        ]
+        name: 'dev'
+      }
+    ]
+    vnetContentShareEnabled: true
+    vnetImagePullEnabled: true
+    vnetRouteAllEnabled: true
+  }
+}
+
+module virtualMachineA 'br/public:avm/res/compute/virtual-machine:0.1.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}-vm-a'
+  params: {
+    // Required parameters
+    adminUsername: 'localAdminUser'
+    imageReference: {
+      publisher: 'MicrosoftWindowsDesktop'
+      offer: 'windows-11'
+      sku: 'win11-24h2-pro'
+      version: 'latest'
+    }
+    name: '${regionName}-vm-a'
+    location: resourceLocation
+    nicConfigurations: [
+      {
+        ipConfigurations: [
+          {
+            name: 'ipconfig01'
+            subnetResourceId: virtualNetwork.outputs.subnetResourceIds[3]
+          }
+        ]
+        nicSuffix: '-nic-01'
+        enablePublicIP: false
+        enableAcceleratedNetworking: false // Accelerated Networking is not supported for B1s
+      }
+    ]
+    osDisk: {
+      caching: 'ReadWrite'
+      diskSizeGB: '256'
+      managedDisk: {
+        storageAccountType: 'Premium_LRS'
+      }
+    }
+    osType: 'Windows'
+    vmSize: 'Standard_D2s_v3'
+    // encryptionAtHost: true // default true if not working use 'az feature register --name EncryptionAtHost --namespace Microsoft.Compute'
+    // Non-required parameters
+    adminPassword: 'Password1234!'
+  }
+}

--- a/ase/main.bicep
+++ b/ase/main.bicep
@@ -1,0 +1,24 @@
+targetScope = 'subscription'
+
+param resourceLocation string = 'italynorth'
+
+resource rgase 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-ase'
+  location: resourceLocation
+}
+
+module ase './ase.bicep' = {
+  scope: rgase
+  name: 'ase'
+  params: {
+    resourceLocation: resourceLocation
+    regionName: 'global'
+    globalPrivatAddressPrefix: '10.0.0.0/8'
+    addressPrefixHub: '10.0.0.0/24' 
+    addressPrefixApplicationGateway: '10.0.0.192/26'
+    applicationGatewayIpAdress: '10.0.0.196'
+    adressPrefixASE: '10.0.0.0/25'
+    addressPrefixBastion: '10.0.0.128/29'
+  }
+}
+


### PR DESCRIPTION
This pull request introduces significant changes to the Azure Service Environment (ASE) deployment scripts, adding new parameters and modules to enhance deployment flexibility and resource management.

### New Parameters and Modules:

* [`ase/ase.bicep`](diffhunk://#diff-db092592fdeed85a475b62a21e9571343fb08b815a30b3d36346c50e9985525dR1-R280): Added multiple parameters for resource location, region name, and address prefixes. Introduced modules for virtual network, bastion host, ASE, app service plans, web apps, and a virtual machine.
* [`ase/main.bicep`](diffhunk://#diff-d3decce41bee960aa157e25406c613b677d079453abc91332c8a2313f467bd88R1-R24): Set the target scope to 'subscription' and defined a resource group for ASE. Included a module to deploy ASE with the newly added parameters.

### Deployment Command:

* [`ase/.cheatsheet`](diffhunk://#diff-3aa28271e35c861dd3a1dc8092657e23e7136f9e0844e6349095ae591f2d4513R1-R2): Added a command to create a deployment in the 'italynorth' location using the `main.bicep` template file.