### PR TITLE
Resources to test out GitHub Runners with VNET integration

### DIFF
--- a/.github/workflows/nimr.yml
+++ b/.github/workflows/nimr.yml
@@ -1,0 +1,33 @@
+name: Access private resources with Azure Network connected Runners
+
+on:
+  workflow_dispatch:
+    inputs:
+      keyvault-name: 
+        description: 'The name of the Azure Key Vault'
+        required: true
+
+jobs:
+  set-and-read-secret:
+    runs-on: 
+      group: vnet-runners
+      labels: linux
+    steps:
+    #   - name: Checkout repository
+    #     uses: actions/checkout@v3
+
+      - name: Login to Azure using OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set secret in Azure Key Vault
+        run: |
+          az keyvault secret set --vault-name ${{ inputs.keyvault-name }}  --name "MySecret" --value "MySecretValue"
+
+      - name: Read secret from Azure Key Vault
+        run: |
+          secret=$(az keyvault secret show --vault-name ${{ inputs.keyvault-name }} --name "MySecret" --query value -o tsv)
+          echo "The secret value is: $secret"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+id_rsa.pub

--- a/managedrunners/.cheatsheet
+++ b/managedrunners/.cheatsheet
@@ -1,0 +1,2 @@
+az deployment sub create --verbose --location italynorth --name managedrunnerdemo --template-file ./main.bicep
+

--- a/managedrunners/main.bicep
+++ b/managedrunners/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+param resourceLocation string = 'italynorth'
+param peeringNetworkId string = '/subscriptions/1cf7c47a-9984-4a46-9b6d-45dd6e2e4ae3/resourceGroups/rg-managedrunners/providers/Microsoft.Network/virtualNetworks/vnet-runners'
+
+resource rgrunnerdemo 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-managedrunnerdemo'
+  location: resourceLocation
+}
+
+module mainResources './network.bicep' = {
+  scope: rgrunnerdemo
+  name: 'internal'
+  params: {
+    resourceLocation: resourceLocation
+    regionName: 'internal'
+    globalPrivatAddressPrefix: '10.0.0.0/8'
+    addressPrefixHub: '10.0.0.0/24' 
+    addressPrefixApplicationGateway: '10.0.0.192/26'
+    applicationGatewayIpAdress: '10.0.0.196'
+    adressPrefixPrivateLink: '10.0.0.0/25'
+    addressPrefixBastion: '10.0.0.128/29'
+    peeringNetworkId: peeringNetworkId
+  }
+}
+
+
+module privateDNS './privateDNS.bicep' = {
+  scope: rgrunnerdemo
+  name: 'privateDNS'
+  params: {
+    networkIdsAndRegions: concat(
+      mainResources.outputs.networkIdsAndRegions
+    )
+    keyvaults: concat(
+      mainResources.outputs.keyvaults
+    )
+  }
+}

--- a/managedrunners/network.bicep
+++ b/managedrunners/network.bicep
@@ -1,0 +1,207 @@
+param resourceLocation string = 'italynorth'
+
+param regionName string = 'global'
+
+param globalPrivatAddressPrefix string = '10.0.0.0/8'
+param addressPrefixBastion string = '10.0.0.128/29'
+param addressPrefixHub string = '10.0.0.0/24' 
+param addressPrefixApplicationGateway string = '10.0.0.192/26'
+param applicationGatewayIpAdress string = '10.0.0.196'
+param addressPrefixUser string = '10.0.0.136/29'
+param peeringNetworkId string = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-az-00000000/providers/Microsoft.Network/virtualNetworks/vnet-avm-az-00000000'
+param adressPrefixPrivateLink string = '10.0.0.0/25'
+
+module virtualNetwork 'br/public:avm/res/network/virtual-network:0.5.2' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-network-${regionName}'
+  params: {
+    // Required parameters
+    addressPrefixes: [
+      addressPrefixHub
+    ]
+    name: 'vnet-${regionName}'
+    // Non-required parameters
+    location: resourceLocation
+    subnets: [
+      {
+        name: 'ApplicationGatewaySubnet'
+        addressPrefix: addressPrefixApplicationGateway
+      }
+      {
+        name: 'PrivateEndpointSubnet'
+        addressPrefix: adressPrefixPrivateLink
+      }
+      {
+        name: 'AzureBastionSubnet'
+        addressPrefix: addressPrefixBastion
+        // No route table can be attached
+      }
+      {
+        name: 'UserSubnet'
+        addressPrefix: addressPrefixUser
+        // No route table can be attached
+      }
+    ]
+    peerings: [
+      {
+        remoteVirtualNetworkResourceId: peeringNetworkId
+        remotePeeringEnabled: true
+      }
+    ]
+  }
+}
+
+module bastionHost 'br/public:avm/res/network/bastion-host:0.1.1' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}Bastion'
+  params: {
+    // Required parameters
+    name: '${regionName}Bastion'
+    vNetId: virtualNetwork.outputs.resourceId
+    scaleUnits: 1 // testing reducing costs
+    skuName: 'Basic' // testing reducing costs
+    location: resourceLocation
+  }
+}
+
+module virtualMachineA 'br/public:avm/res/compute/virtual-machine:0.1.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}-vm-a'
+  params: {
+    // Required parameters
+    adminUsername: 'localAdminUser'
+    imageReference: {
+      offer: '0001-com-ubuntu-server-jammy'
+      publisher: 'Canonical'
+      sku: '22_04-lts-gen2'
+      version: 'latest'
+    }
+    name: '${regionName}-vm-a'
+    location: resourceLocation
+    nicConfigurations: [
+      {
+        ipConfigurations: [
+          {
+            name: 'ipconfig01'
+            subnetResourceId: virtualNetwork.outputs.subnetResourceIds[3]
+          }
+        ]
+        nicSuffix: '-nic-01'
+        enablePublicIP: false
+        enableAcceleratedNetworking: false // Accelerated Networking is not supported for B1s
+      }
+    ]
+    osDisk: {
+      caching: 'ReadWrite'
+      diskSizeGB: '32'
+      managedDisk: {
+        storageAccountType: 'Premium_LRS'
+      }
+    }
+    osType: 'Linux'
+    vmSize: 'Standard_B1s'
+    // encryptionAtHost: true // default true if not working use 'az feature register --name EncryptionAtHost --namespace Microsoft.Compute'
+    // Non-required parameters
+    disablePasswordAuthentication: true
+    publicKeys: [
+      {
+        keyData: loadTextContent('../id_rsa.pub')
+        path: '/home/localAdminUser/.ssh/authorized_keys'
+      }
+    ]
+    managedIdentities: {
+        systemAssigned: false
+        userAssignedResourceIds: [userAssignedIdentity.outputs.resourceId]
+    }
+  }
+}
+
+module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}-umsi'
+  params: {
+    // Required parameters
+    name: '${regionName}-umsi'
+    // Non-required parameters
+    federatedIdentityCredentials: [
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: 'https://token.actions.githubusercontent.com'
+        name: 'GitHubWorkflowDefault'
+        subject: 'repo:flowsoft-org/azure-verified-modules:ref:refs/heads/main'
+      }
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: 'https://token.actions.githubusercontent.com'
+        name: 'GitHubWorkflowTest'
+        subject: 'repo:flowsoft-org/azure-verified-modules:ref:refs/heads/h2floh/managed-connected-runners-demo'
+      }
+    ]
+    location: resourceLocation
+  }
+}
+
+module vault 'br/public:avm/res/key-vault/vault:0.4.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-kv-${regionName}'
+  params: {
+    // Required parameters
+    name: 'kv-${uniqueString(deployment().name, resourceLocation)}'
+    // Non-required parameters
+    enablePurgeProtection: false
+    sku: 'standard'
+    location: resourceLocation
+    enableRbacAuthorization: true
+    publicNetworkAccess: 'Disabled'
+  }
+}
+
+module kvmsiRoleAssignment 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.2' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-kvrole-${regionName}'
+  params: {
+    // Required parameters
+    principalId: userAssignedIdentity.outputs.principalId
+    resourceId: vault.outputs.resourceId
+    roleDefinitionId: 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7' // 'Key Vault Secrets Officer'
+    // Non-required parameters
+    description: 'Role assignment for the user assigned identity'
+    principalType: 'ServicePrincipal'
+  }
+}
+
+module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.4.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-pekv-${regionName}'
+  params: {
+    // Required parameters
+    name: 'privateEndpoint-kv-${regionName}'
+    subnetResourceId: virtualNetwork.outputs.subnetResourceIds[1]
+    // Non-required parameters
+    location: resourceLocation
+    lock: {}
+    manualPrivateLinkServiceConnections: []
+    privateLinkServiceConnections: [
+      {
+        name: 'pekv-${regionName}'
+        properties: {
+          groupIds: [
+            'vault'
+          ]
+          privateLinkServiceId: vault.outputs.resourceId
+        }
+      }
+    ]
+  }
+}
+
+output keyvaults array = [
+  {
+    keyvaultName: vault.outputs.name
+    privateEndpointName: privateEndpoint.outputs.name
+  }
+]
+
+output networkIdsAndRegions array = [
+  {
+    networkid: virtualNetwork.outputs.resourceId
+    region: regionName
+  }
+]

--- a/managedrunners/privateDNS.bicep
+++ b/managedrunners/privateDNS.bicep
@@ -1,0 +1,63 @@
+param networkIdsAndRegions array = [
+  {
+    region: 'eastus'
+    networkid: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-az-00000000/providers/Microsoft.Network/virtualNetworks/vnet-avm-az-00000000'
+  }
+]
+
+param keyvaults array = [
+  {
+    keyvaultName: 'kv-avm-az-00000000'
+    privateEndpointName: 'pe-avm-az-00000000'
+  }
+]
+
+module privateDnsZone 'br/public:avm/res/network/private-dns-zone:0.2.4' = [for region in reduce(map(networkIdsAndRegions, element => [element.region]), [], (cur, next) => union(cur, next)): {
+  name: '${uniqueString(deployment().name, 'global')}-dns-regions-${region}'
+  params: {
+    // Required parameters
+    name: '${region}.flow-soft.internal'
+    // Non-required parameters
+    location: 'global'
+    virtualNetworkLinks: [
+      for networkIdAndRegionLink in networkIdsAndRegions : {
+        virtualNetworkResourceId: networkIdAndRegionLink.networkid
+        registrationEnabled: (networkIdAndRegionLink.region == region) ? true : false
+      }
+    ]
+  }
+}]
+
+resource pepoints 'Microsoft.Network/privateEndpoints@2023-04-01' existing = [for keyvaultIp in keyvaults : {
+  name: keyvaultIp.privateEndpointName
+}]
+
+module privateDnsZoneKeyVault 'br/public:avm/res/network/private-dns-zone:0.2.4' = {
+  dependsOn: [
+    pepoints
+  ]
+  name: '${uniqueString(deployment().name, 'global')}-dns-keyvault-global'
+  params: {
+    // Required parameters
+    name: 'privatelink.vaultcore.azure.net'
+    // Non-required parameters
+    location: 'global'
+    virtualNetworkLinks: [
+      for networkIdAndRegionLink in networkIdsAndRegions : {
+        virtualNetworkResourceId: networkIdAndRegionLink.networkid
+        registrationEnabled: false
+      }
+    ]
+    a: [
+      for (keyvaultIp, index) in keyvaults : {
+        aRecords: [
+          {
+            ipv4Address: pepoints[index].properties.customDnsConfigs[0].ipAddresses[0]
+          }
+        ]
+        name: keyvaultIp.keyvaultName
+        ttl: 3600
+      }
+    ]
+  }
+}

--- a/starhubspoke/hubSpoke.bicep
+++ b/starhubspoke/hubSpoke.bicep
@@ -669,7 +669,7 @@ module virtualMachineA 'br/public:avm/res/compute/virtual-machine:0.1.0' = {
     disablePasswordAuthentication: true
     publicKeys: [
       {
-        keyData: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDbayTrbSOQE+jlz+PzfJQzIHgATX2Gj+owdpD1/HHqtDrXMd6SqNlyf3/k0pYbCsXjA/A7MzJgAT1Kj5GwjGlDkIQA8kjVW9TByPDV+s//C6vTy1H6dE4jZYvTeolsm7JBkGOyTXI+pcL6vLkhzWIESxkeUG/LR08UPWVjcfk2Oqsk2I/AUiZxWhWcVIYasfJSHolrOHPcRdLNQoAY7iw3vrq4kw6DkcTVa9BTdxt0sym/j6TPMAJgA1z53ONt38PywIZ/Fb/dQer5QusOSJS4+rKR9gYHOAio3TWnmG7azERXpD2btD4OV4jvFhDx2EuFhRC4ZYLaPX5dnd4FIM2yhFi/zFWoCpYOSIZt21DMYr4qTZWP0arf/IL23ZkxssQlNTKlYdANfc1R0r7JMJO36/xZZq1h8N80MHKMyWWuXOYfGksrh617jqysOY20F09f0HpdES3oWN4vpRCWSAmDLyLnljg0Z20NTrKxDcCcAXj3vcZzxB+9UPnAQlfeX9c='
+        keyData: loadTextContent('../id_rsa.pub')
         path: '/home/localAdminUser/.ssh/authorized_keys'
       }
     ]
@@ -719,7 +719,7 @@ module virtualMachineB 'br/public:avm/res/compute/virtual-machine:0.1.0' = {
     disablePasswordAuthentication: true
     publicKeys: [
       {
-        keyData: 'ssh-rsa keydata'
+        keyData: loadTextContent('../id_rsa.pub')
         path: '/home/localAdminUser/.ssh/authorized_keys'
       }
     ]


### PR DESCRIPTION
This pull request includes several changes to the configuration and deployment scripts for managing Azure resources and GitHub runners. The most important changes include the addition of a new GitHub Actions workflow, updates to Bicep deployment scripts, and the inclusion of a new cheat sheet command.

### GitHub Actions Workflow:
* Added a new GitHub Actions workflow to access private resources with Azure Network connected Runners. This workflow includes steps for logging into Azure, testing Key Vault DNS resolution, and setting and reading secrets from Azure Key Vault. (`.github/workflows/nimr.yml`)

### Bicep Deployment Scripts:
* Updated the `main.bicep` script to define parameters for resource locations and network configurations, and to include modules for setting up resources such as virtual networks, bastion hosts, virtual machines, key vaults, and private endpoints. (`managedrunners/main.bicep`)
* Updated the `network.bicep` script to define parameters and modules for creating virtual networks, subnets, and network peerings. (`managedrunners/network.bicep`)
* Added a new `privateDNS.bicep` script to configure private DNS zones and link them to virtual networks and key vaults. (`managedrunners/privateDNS.bicep`)

### Cheat Sheet:
* Added a new command to the `.cheatsheet` file for creating a deployment using a Bicep template. (`managedrunners/.cheatsheet`)

### Key Updates in Virtual Machine Configuration:
* Updated the `hubSpoke.bicep` script to load SSH public keys from a file instead of hardcoding them. (`starhubspoke/hubSpoke.bicep`) [[1]](diffhunk://#diff-e08619be28db184aaa69d3a53ac533a9bbcff37b0a33bdecf6d41a787b38a695L672-R672) [[2]](diffhunk://#diff-e08619be28db184aaa69d3a53ac533a9bbcff37b0a33bdecf6d41a787b38a695L722-R722)