### PR TITLE
DNS IaC Solution dependency fix

### DIFF
--- a/.github/workflows/dns-deploy.yml
+++ b/.github/workflows/dns-deploy.yml
@@ -44,6 +44,7 @@ jobs:
             --location ${{ inputs.location }} \
             --template-file ./main.bicep \
             --parameters resourceLocation='${{ inputs.location }}' \
+            --parameters publicKey='${{ secrets.PUBLIC_KEY }}' \
             --name dns-deployment-${{ inputs.environment }}-$(date +%Y%m%d-%H%M%S)
 
       - name: Display Deployment Status

--- a/dns/dns.bicep
+++ b/dns/dns.bicep
@@ -2,6 +2,8 @@ param resourceLocation string = 'swedencentral'
 
 param regionName string = 'swedencentral'
 
+param publicKey string
+
 param main bool = true
 param addressPrefix string = '10.0.0.0/24' 
 param addressPrefixBastion string = '10.0.0.0/26'
@@ -104,7 +106,8 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:0.1.0' = if (ma
     disablePasswordAuthentication: true
     publicKeys: [
       {
-        keyData: 'ssh-rsa keydata'
+        // sample content of publicKey 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAr...'
+        keyData: publicKey
         path: '/home/localAdminUser/.ssh/authorized_keys'
       }
     ]

--- a/dns/dns.bicep
+++ b/dns/dns.bicep
@@ -64,9 +64,6 @@ module bastionHost 'br/public:avm/res/network/bastion-host:0.1.1' = if (main) {
 }
 
 module virtualMachine 'br/public:avm/res/compute/virtual-machine:0.1.0' = if (main) {
-  dependsOn: [
-    virtualNetwork
-  ]
   name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}-vm'
   params: {
     // Required parameters
@@ -170,6 +167,9 @@ module dnsResolver 'br/public:avm/res/network/dns-resolver:0.3.0' = if (main) {
 }
 
 module dnsForwardingRuleset 'br/public:avm/res/network/dns-forwarding-ruleset:0.2.5' = if (main) {
+  dependsOn: [
+    dnsResolver
+  ]
   name: '${uniqueString(deployment().name, resourceLocation)}-${regionName}-dnsForwardingRulesetDeployment'
   params: {
     // Required parameters

--- a/dns/main.bicep
+++ b/dns/main.bicep
@@ -1,6 +1,7 @@
 targetScope = 'subscription'
 
 param resourceLocation string = 'swedencentral'
+param publicKey string
 
 resource rgdnsprime 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: 'rg-dns-primary'
@@ -19,6 +20,7 @@ module dnstest './dns.bicep' = {
     main: true
     resourceLocation: 'swedencentral'
     regionName: 'A'
+    publicKey: publicKey
     addressPrefix: '10.0.0.0/24' 
     addressPrefixBastion: '10.0.0.0/26'
     addressPrefixVM: '10.0.0.64/26'
@@ -33,6 +35,7 @@ module dnstest2 './dns.bicep' = {
     main: false
     resourceLocation: 'swedencentral'
     regionName: 'B'
+    publicKey: publicKey
     addressPrefix: '10.0.0.0/24' 
     addressPrefixBastion: '10.0.0.0/26'
     addressPrefixVM: '10.0.0.64/26'


### PR DESCRIPTION
This pull request updates the DNS deployment workflow and Bicep templates to support passing an SSH public key securely from GitHub secrets into the virtual machine deployment, and improves resource dependency handling in the Bicep modules. The main changes focus on parameterizing the SSH public key, ensuring it is used in VM provisioning, and refining deployment dependencies.

**SSH Public Key Parameterization and Secure Injection:**

* Added a `publicKey` parameter to both `dns/main.bicep` and `dns/dns.bicep`, allowing the SSH public key to be passed in as a parameter rather than being hardcoded. [[1]](diffhunk://#diff-e3e0bac510988092270d2c4d506f139f61e242514dd6f6d44787555f8df21fb4R4) [[2]](diffhunk://#diff-f97683c7952f161be049ef2746cf1eef8648ad2fbf06e6fe11e63daed0a2c68cR5-R6)
* Updated the GitHub Actions workflow (`.github/workflows/dns-deploy.yml`) to pass the `PUBLIC_KEY` secret as the `publicKey` parameter during deployment.
* Modified the VM provisioning in `dns/dns.bicep` to use the provided `publicKey` parameter for the SSH key, replacing the previous hardcoded value.
* Updated module invocations in `dns/main.bicep` to pass the `publicKey` parameter to both `dnstest` and `dnstest2` modules. [[1]](diffhunk://#diff-e3e0bac510988092270d2c4d506f139f61e242514dd6f6d44787555f8df21fb4R23) [[2]](diffhunk://#diff-e3e0bac510988092270d2c4d506f139f61e242514dd6f6d44787555f8df21fb4R38)

**Resource Dependency Improvements:**

* Added `dependsOn` for the `dnsForwardingRuleset` module to ensure it is deployed after `dnsResolver`, improving deployment reliability.
* Removed unnecessary `dependsOn` from the `virtualMachine` module, simplifying the deployment dependency graph.